### PR TITLE
Modularize camera_refiner

### DIFF
--- a/dense_map/geometry_mapper/CMakeLists.txt
+++ b/dense_map/geometry_mapper/CMakeLists.txt
@@ -208,6 +208,10 @@ add_executable(orthoproject tools/orthoproject.cc)
 target_link_libraries(orthoproject
     geometry_mapper_lib gflags glog)
 
+add_executable(test_texture_gen tools/test_texture_gen.cc)
+target_link_libraries(test_texture_gen
+    geometry_mapper_lib gflags glog)
+
 add_executable(old_orthoproject tools/old_orthoproject.cc)
 target_link_libraries(old_orthoproject
     geometry_mapper_lib gflags glog)

--- a/dense_map/geometry_mapper/include/camera_image.h
+++ b/dense_map/geometry_mapper/include/camera_image.h
@@ -1,0 +1,62 @@
+/* Copyright (c) 2021, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ *
+ * All rights reserved.
+ *
+ * The "ISAAC - Integrated System for Autonomous and Adaptive Caretaking
+ * platform" software is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CAMERA_IMAGE_H_
+#define CAMERA_IMAGE_H_
+
+#include <opencv2/imgproc.hpp>
+
+namespace dense_map {
+
+// A class to encompass all known information about a camera
+struct cameraImage {
+  // An index to look up the type of camera. This will equal the
+  // value ref_camera_type if and only if this is a reference
+  // camera.
+  int camera_type;
+
+  // The timestamp for this camera (in floating point seconds since epoch)
+  // measured by the clock/cpu which is particular to this camera.
+  double timestamp;
+
+  // The timestamp with an adjustment added to it to be in
+  // reference camera time
+  double ref_timestamp;
+
+  // The timestamp of the closest cloud for this image, measured
+  // with the same clock as the 'timestamp' value.
+  double cloud_timestamp;
+
+  // Indices to look up the reference cameras bracketing this camera
+  // in time. The two indices will have same value if and only if
+  // this is a reference camera.
+  int beg_ref_index;
+  int end_ref_index;
+
+  // The image for this camera, in grayscale
+  cv::Mat image;
+
+  // The corresponding depth cloud, for an image + depth camera.
+  // Will be empty and uninitialized for a camera lacking depth.
+  cv::Mat depth_cloud;
+};
+
+}  // namespace dense_map
+
+#endif  // CAMERA_IMAGE_H_

--- a/dense_map/geometry_mapper/include/dense_map_utils.h
+++ b/dense_map/geometry_mapper/include/dense_map_utils.h
@@ -216,16 +216,6 @@ void pickTimestampsInBounds(std::vector<double> const& timestamps, double left_b
 // Must always have NUM_EXIF the last.
 enum ExifData { TIMESTAMP = 0, EXPOSURE_TIME, ISO, APERTURE, FOCAL_LENGTH, NUM_EXIF };
 
-// Triangulate two rays emanating from given undistorted and centered pixels
-Eigen::Vector3d TriangulatePair(double focal_length1, double focal_length2, Eigen::Affine3d const& world_to_cam1,
-                                Eigen::Affine3d const& world_to_cam2, Eigen::Vector2d const& pix1,
-                                Eigen::Vector2d const& pix2);
-
-// Triangulate n rays emanating from given undistorted and centered pixels
-Eigen::Vector3d Triangulate(std::vector<double> const& focal_length_vec,
-                            std::vector<Eigen::Affine3d> const& world_to_cam_vec,
-                            std::vector<Eigen::Vector2d> const& pix_vec);
-
 // A utility for saving a camera in a format ASP understands.
 // TODO(oalexan1): Expose the sci cam intrinsics rather than having
 // them hard-coded.

--- a/dense_map/geometry_mapper/include/texture_processing.h
+++ b/dense_map/geometry_mapper/include/texture_processing.h
@@ -38,6 +38,7 @@
 #include <tex/tri.h>
 #include <tex/texture_patch.h>
 #include <tex/rectangular_bin.h>
+#include <tex/material_lib.h>
 #include <util/exception.h>
 #include <math/vector.h>
 
@@ -77,7 +78,7 @@ struct FaceInfo {
   int64_t width, height;
 
   // The padding to apply to each face bounding box before sampling it
-  int64_t padding;
+  int64_t face_info_padding;
 
   // The pixel at (x, min_y, min_z) in the plane will end up at location (shift_u, shift_v)
   // in the texture.
@@ -100,7 +101,7 @@ struct FaceInfo {
     min_z   = 0.0;
     width   = 0L;
     height  = 0L;
-    padding = 0L;
+    face_info_padding = 1L;
     valid = true;
     shift_u = std::numeric_limits<int>::max();
     shift_v = 0L;
@@ -119,7 +120,7 @@ class IsaacTexturePatch {
   typedef std::shared_ptr<IsaacTexturePatch> Ptr;
   typedef std::shared_ptr<const IsaacTexturePatch> ConstPtr;
   typedef std::vector<std::size_t> Faces;
-  typedef std::vector<math::Vec2f> Texcoords;
+  typedef std::vector<Eigen::Vector2d> Texcoords;
 
  private:
   int64_t label;
@@ -129,21 +130,23 @@ class IsaacTexturePatch {
 
  public:
   /** Constructs a texture patch. */
-  IsaacTexturePatch(int64_t label, std::vector<std::size_t> const& faces, std::vector<math::Vec2f> const& texcoords,
+  IsaacTexturePatch(int64_t label, std::vector<std::size_t> const& faces,
+                    std::vector<Eigen::Vector2d> const& texcoords,
                     int64_t width, int64_t height);
 
   IsaacTexturePatch(IsaacTexturePatch const& texture_patch);
 
   static IsaacTexturePatch::Ptr create(IsaacTexturePatch::ConstPtr texture_patch);
   static IsaacTexturePatch::Ptr create(int64_t label, std::vector<std::size_t> const& faces,
-                                       std::vector<math::Vec2f> const& texcoords, int64_t width, int64_t height);
+                                       std::vector<Eigen::Vector2d> const& texcoords,
+                                       int64_t width, int64_t height);
 
   IsaacTexturePatch::Ptr duplicate(void);
 
   std::vector<std::size_t>& get_faces(void);
   std::vector<std::size_t> const& get_faces(void) const;
-  std::vector<math::Vec2f>      & get_texcoords(void);
-  std::vector<math::Vec2f> const& get_texcoords(void) const;
+  std::vector<Eigen::Vector2d>      & get_texcoords(void);
+  std::vector<Eigen::Vector2d> const& get_texcoords(void) const;
 
   int64_t get_label(void) const;
   int64_t get_width(void) const;
@@ -152,13 +155,14 @@ class IsaacTexturePatch {
 };
 
 inline IsaacTexturePatch::IsaacTexturePatch(int64_t label, std::vector<std::size_t> const& faces,
-                                            std::vector<math::Vec2f> const& texcoords, int64_t width, int64_t height)
+                                            std::vector<Eigen::Vector2d> const& texcoords,
+                                            int64_t width, int64_t height)
     : label(label), faces(faces), texcoords(texcoords), width(width), height(height) {}
 
 IsaacTexturePatch::IsaacTexturePatch(IsaacTexturePatch const& texture_patch) {
   label = texture_patch.label;
   faces = std::vector<std::size_t>(texture_patch.faces);
-  texcoords = std::vector<math::Vec2f>(texture_patch.texcoords);
+  texcoords = std::vector<Eigen::Vector2d>(texture_patch.texcoords);
   width = texture_patch.width;
   height = texture_patch.height;
 }
@@ -167,9 +171,9 @@ inline IsaacTexturePatch::Ptr IsaacTexturePatch::create(IsaacTexturePatch::Const
   return std::make_shared<IsaacTexturePatch>(*texture_patch);
 }
 
-inline IsaacTexturePatch::Ptr IsaacTexturePatch::create(int64_t label, std::vector<std::size_t> const& faces,
-                                                        std::vector<math::Vec2f> const& texcoords, int64_t width,
-                                                        int64_t height) {
+inline IsaacTexturePatch::Ptr IsaacTexturePatch::create(
+  int64_t label, std::vector<std::size_t> const& faces,
+  std::vector<Eigen::Vector2d> const& texcoords, int64_t width, int64_t height) {
   return std::make_shared<IsaacTexturePatch>(label, faces, texcoords, width, height);
 }
 
@@ -183,13 +187,13 @@ inline int64_t IsaacTexturePatch::get_width(void) const { return width; }
 
 inline int64_t IsaacTexturePatch::get_height(void) const { return height; }
 
-inline std::vector<math::Vec2f>& IsaacTexturePatch::get_texcoords(void) {
+inline std::vector<Eigen::Vector2d>& IsaacTexturePatch::get_texcoords(void) {
   return texcoords;
 }
 
 inline std::vector<std::size_t>& IsaacTexturePatch::get_faces(void) { return faces; }
 
-inline std::vector<math::Vec2f> const& IsaacTexturePatch::get_texcoords(void) const {
+inline std::vector<Eigen::Vector2d> const& IsaacTexturePatch::get_texcoords(void) const {
   return texcoords;
 }
 
@@ -198,7 +202,8 @@ inline std::vector<std::size_t> const& IsaacTexturePatch::get_faces(void) const 
 inline int64_t IsaacTexturePatch::get_size(void) const { return get_width() * get_height(); }
 
 /**
- * Class representing a texture atlas.
+ * Class representing a texture atlas. Have to duplicate the code from texrecon
+ * as there are custom changes for ISAAC.
  */
 class IsaacTextureAtlas {
  public:
@@ -206,14 +211,13 @@ class IsaacTextureAtlas {
 
   typedef std::vector<std::size_t> Faces;
   typedef std::vector<std::size_t> TexcoordIds;
-  typedef std::vector<math::Vec2f> Texcoords;
+  typedef std::vector<Eigen::Vector2d> Texcoords;
 
   int64_t get_width();
   int64_t get_height();
 
  private:
   int64_t width, height, determined_height;
-  int64_t const padding;
   bool finalized;
 
   Faces faces;
@@ -263,6 +267,80 @@ inline int64_t IsaacTextureAtlas::get_width() { return width; }
 
 inline int64_t IsaacTextureAtlas::get_height() { return height; }
 
+
+/**
+ * Class representing a obj model. Have to duplicate the texrecon structure, as
+ * we use double-precision texcoords.
+  */
+class IsaacObjModel {
+ public:
+  struct Face {
+    std::size_t vertex_ids[3];
+    std::size_t texcoord_ids[3];
+    std::size_t normal_ids[3];
+  };
+
+    struct Group {
+        std::string material_name;
+        std::vector<Face> faces;
+    };
+
+    typedef std::vector<math::Vec3f> Vertices;
+    typedef std::vector<Eigen::Vector2d> TexCoords;
+    typedef std::vector<math::Vec3f> Normals;
+    typedef std::vector<Group> Groups;
+
+ private:
+    Vertices vertices;
+    TexCoords texcoords;
+    Normals normals;
+    Groups groups;
+    MaterialLib material_lib;
+
+ public:
+    /** Saves the obj model to an .obj file, its material lib and the
+        materials with the given prefix. */
+    void save_to_files(std::string const & prefix) const;
+
+    MaterialLib & get_material_lib(void);
+    Vertices & get_vertices(void);
+    TexCoords & get_texcoords(void);
+    Normals & get_normals(void);
+    Groups & get_groups(void);
+
+    static void save(IsaacObjModel const & model, std::string const & prefix);
+};
+
+inline
+MaterialLib &
+IsaacObjModel::get_material_lib(void) {
+    return material_lib;
+}
+
+inline
+IsaacObjModel::Vertices &
+IsaacObjModel::get_vertices(void) {
+    return vertices;
+}
+
+inline
+IsaacObjModel::TexCoords &
+IsaacObjModel::get_texcoords(void) {
+    return texcoords;
+}
+
+inline
+IsaacObjModel::Normals &
+IsaacObjModel::get_normals(void) {
+    return normals;
+}
+
+inline
+IsaacObjModel::Groups &
+IsaacObjModel::get_groups(void) {
+    return groups;
+}
+
 // Load and prepare a mesh
 void loadMeshBuildTree(std::string const& mesh_file, mve::TriangleMesh::Ptr& mesh,
                        std::shared_ptr<mve::MeshInfo>& mesh_info,
@@ -271,11 +349,12 @@ void loadMeshBuildTree(std::string const& mesh_file, mve::TriangleMesh::Ptr& mes
 
 void formModel(mve::TriangleMesh::ConstPtr mesh, double pixel_size, int64_t num_threads,
                // outputs
-               std::vector<FaceInfo>& face_projection_info, std::vector<IsaacTextureAtlas::Ptr>& texture_atlases,
-               tex::Model& model);
+               std::vector<FaceInfo>& face_projection_info,
+               std::vector<IsaacTextureAtlas::Ptr>& texture_atlases,
+               IsaacObjModel& model);
 
 // Put an textured mesh obj file in a string
-void formObj(tex::Model& texture_model, std::string const& out_prefix, std::string& obj_str);
+void formObj(IsaacObjModel& texture_model, std::string const& out_prefix, std::string& obj_str);
 
 // Put an textured mesh obj file in a string
 void formObjCustomUV(mve::TriangleMesh::ConstPtr mesh, std::vector<Eigen::Vector3i> const& face_vec,
@@ -299,17 +378,31 @@ void projectTexture(mve::TriangleMesh::ConstPtr mesh, std::shared_ptr<BVHTree> b
 
 // Project texture on a texture model that was pre-filled already, so
 // only the texture pixel values need to be computed
-void projectTexture(mve::TriangleMesh::ConstPtr mesh, std::shared_ptr<BVHTree> bvh_tree, cv::Mat const& image,
-                    camera::CameraModel const& cam, std::vector<double>& smallest_cost_per_face, double pixel_size,
+void projectTexture(mve::TriangleMesh::ConstPtr mesh, std::shared_ptr<BVHTree> bvh_tree,
+                    cv::Mat const& image, camera::CameraModel const& cam,
+                    std::vector<double>& smallest_cost_per_face, double pixel_size,
                     int64_t num_threads, std::vector<FaceInfo> const& face_projection_info,
-                    std::vector<IsaacTextureAtlas::Ptr>& texture_atlases, tex::Model& model, cv::Mat& out_texture);
+                    std::vector<IsaacTextureAtlas::Ptr>& texture_atlases,
+                    IsaacObjModel& model, cv::Mat& out_texture);
 
-void meshProject(mve::TriangleMesh::Ptr const& mesh, std::shared_ptr<BVHTree> const& bvh_tree, cv::Mat const& image,
+// Find where ray emanating from a distorted pixel intersects a mesh. Return true
+// on success.
+bool ray_mesh_intersect(Eigen::Vector2d const& dist_pix,
+                        camera::CameraParameters const& cam_params,
+                        Eigen::Affine3d const& world_to_cam,
+                        mve::TriangleMesh::Ptr const& mesh,
+                        std::shared_ptr<BVHTree> const& bvh_tree,
+                        double min_ray_dist, double max_ray_dist,
+                        // Output
+                        Eigen::Vector3d& intersection);
+
+void meshProject(mve::TriangleMesh::Ptr const& mesh, std::shared_ptr<BVHTree> const& bvh_tree,
+                 cv::Mat const& image,
                  Eigen::Affine3d const& world_to_cam, camera::CameraParameters const& cam_params,
                  int64_t num_exclude_boundary_pixels, std::string const& out_prefix);
 
 // Save a model
-void isaac_save_model(ObjModel* obj_model, std::string const& prefix);
+void isaac_save_model(IsaacObjModel* obj_model, std::string const& prefix);
 
 }  // namespace dense_map
 

--- a/dense_map/geometry_mapper/readme.md
+++ b/dense_map/geometry_mapper/readme.md
@@ -1575,6 +1575,12 @@ If the ``--out_texture_dir`` option is specified, the tool will create
 textured meshes for each image and optimized camera at the
 end. Ideally those textured meshes will agree among each other.
 
+### The algorithm
+
+See camera_refiner.cc for a lengthy explanation of the algorithm.
+
+### Camera refiner options
+
 This program's options are:
 
     --ros_bag (string, default = "")
@@ -1677,6 +1683,10 @@ This program's options are:
       Override the value of nav_cam_to_sci_cam_timestamp_offset from
       the robot config file with this value.
 
+    --sci_cam_timestamps (string, default = "")
+      Use only these sci cam timestamps. Must be a file with one
+      timestamp per line.
+
     --depth_tri_weight (double, default = 1000.0)
       The weight to give to the constraint that depth measurements
       agree with triangulated points. Use a bigger number as depth
@@ -1729,9 +1739,6 @@ This program's options are:
       other relative to the triangulated points, so care is needed
       here.
 
-    --refiner_skip_filtering (bool, false unless specified)
-      Do not do any outlier filtering.
-
     --out_texture_dir (string, default = "")
       If non-empty and if an input mesh was provided, project the
       camera images using the optimized poses onto the mesh and write
@@ -1777,9 +1784,9 @@ This program's options are:
     --num_opt_threads (int32, default = 16)
       How many threads to use in the optimization.
 
-    --sci_cam_timestamps (string, default = "")
-      Use only these sci cam timestamps. Must be a file with one
-      timestamp per line.
+    --num_match_threads (int32, default = 8)
+      How many threads to use in feature detection/matching.
+      A large number can use a lot of memory.
 
     --verbose (bool, false unless specified)
       Print the residuals and save the images and match files. Stereo
@@ -1808,6 +1815,11 @@ extrinsics). The new best-fit distortion model will be written to disk
 at the end, replacing the fisheye model, and from then on the new
 model can be used for further calibration experiments just as with the
 fisheye model.
+
+It may however be needed to rerun the refiner one more time, this time
+with the new distortion model read from disk, and still keep all
+intrinsics and extrinsics (including the sparse map and depth to
+image) fixed, except for the nav cam distortion, to fully tighten it.
 
 Since it is expected that fitting such a model is harder at the
 periphery, where the distortion is stronger, the camera refiner has

--- a/dense_map/geometry_mapper/src/interest_point.cc
+++ b/dense_map/geometry_mapper/src/interest_point.cc
@@ -22,7 +22,19 @@
 #include <opencv2/calib3d/calib3d.hpp>
 
 #include <interest_point.h>           // from the isaac repo
+#include <camera_image.h>             // from the isaac repo
 #include <interest_point/matching.h>  // from the astrobee repo
+
+// Get rid of warnings beyond our control
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic push
+#include <openMVG/multiview/projection.hpp>
+#include <openMVG/multiview/rotation_averaging_l1.hpp>
+#include <openMVG/multiview/triangulation_nview.hpp>
+#include <openMVG/numeric/numeric.h>
+#include <openMVG/tracks/tracks.hpp>
+#pragma GCC diagnostic pop
 
 #include <boost/filesystem.hpp>
 
@@ -155,6 +167,131 @@ void matchFeatures(std::mutex* match_mutex, int left_image_index, int right_imag
   match_mutex->unlock();
 }
 
+
+// Match features while assuming that the input cameras can be used to filter out
+// outliers by reprojection error.
+void matchFeaturesWithCams(std::mutex* match_mutex, int left_image_index, int right_image_index,
+                           camera::CameraParameters const& left_params,
+                           camera::CameraParameters const& right_params,
+                           Eigen::Affine3d const& left_world_to_cam,
+                           Eigen::Affine3d const& right_world_to_cam,
+                           double reprojection_error,
+                           cv::Mat const& left_descriptors, cv::Mat const& right_descriptors,
+                           Eigen::Matrix2Xd const& left_keypoints,
+                           Eigen::Matrix2Xd const& right_keypoints,
+                           bool verbose,
+                           // output
+                           MATCH_PAIR* matches) {
+  // Match by using descriptors first
+  std::vector<cv::DMatch> cv_matches;
+  interest_point::FindMatches(left_descriptors, right_descriptors, &cv_matches);
+
+  // Do filtering
+  std::vector<cv::Point2f> left_vec;
+  std::vector<cv::Point2f> right_vec;
+  std::vector<cv::DMatch> filtered_cv_matches;
+  for (size_t j = 0; j < cv_matches.size(); j++) {
+    int left_ip_index = cv_matches.at(j).queryIdx;
+    int right_ip_index = cv_matches.at(j).trainIdx;
+
+    Eigen::Vector2d dist_left_ip(left_keypoints.col(left_ip_index)[0],
+                                 left_keypoints.col(left_ip_index)[1]);
+
+    Eigen::Vector2d dist_right_ip(right_keypoints.col(right_ip_index)[0],
+                                  right_keypoints.col(right_ip_index)[1]);
+
+    Eigen::Vector2d undist_left_ip;
+    Eigen::Vector2d undist_right_ip;
+    left_params.Convert<camera::DISTORTED,  camera::UNDISTORTED_C>
+      (dist_left_ip, &undist_left_ip);
+    right_params.Convert<camera::DISTORTED, camera::UNDISTORTED_C>
+      (dist_right_ip, &undist_right_ip);
+
+    Eigen::Vector3d X =
+      dense_map::TriangulatePair(left_params.GetFocalLength(), right_params.GetFocalLength(),
+                                 left_world_to_cam, right_world_to_cam,
+                                 undist_left_ip, undist_right_ip);
+
+    // Project back into the cameras
+    Eigen::Vector3d left_cam_X = left_world_to_cam * X;
+    Eigen::Vector2d undist_left_pix
+      = left_params.GetFocalVector().cwiseProduct(left_cam_X.hnormalized());
+    Eigen::Vector2d dist_left_pix;
+    left_params.Convert<camera::UNDISTORTED_C, camera::DISTORTED>(undist_left_pix,
+                                                                  &dist_left_pix);
+
+    Eigen::Vector3d right_cam_X = right_world_to_cam * X;
+    Eigen::Vector2d undist_right_pix
+      = right_params.GetFocalVector().cwiseProduct(right_cam_X.hnormalized());
+    Eigen::Vector2d dist_right_pix;
+    right_params.Convert<camera::UNDISTORTED_C, camera::DISTORTED>(undist_right_pix,
+                                                                   &dist_right_pix);
+
+    // Filter out points whose reprojection error is too big
+    bool is_good = ((dist_left_ip - dist_left_pix).norm() <= reprojection_error &&
+                    (dist_right_ip - dist_right_pix).norm() <= reprojection_error);
+
+    // If any values above are Inf or NaN, is_good will be false as well
+    if (!is_good) continue;
+
+    // Get the keypoints from the good matches
+    left_vec.push_back(cv::Point2f(left_keypoints.col(left_ip_index)[0],
+                                   left_keypoints.col(left_ip_index)[1]));
+    right_vec.push_back(cv::Point2f(right_keypoints.col(right_ip_index)[0],
+                                    right_keypoints.col(right_ip_index)[1]));
+
+    filtered_cv_matches.push_back(cv_matches[j]);
+  }
+
+  if (left_vec.empty()) return;
+
+  // Filter using geometry constraints
+  // These may need some tweaking but works reasonably well.
+  double ransacReprojThreshold = 20.0;
+  cv::Mat inlier_mask;
+  int maxIters = 10000;
+  double confidence = 0.8;
+
+  // affine2D works better than homography
+  // cv::Mat H = cv::findHomography(left_vec, right_vec, cv::RANSAC,
+  // ransacReprojThreshold, inlier_mask, maxIters, confidence);
+  cv::Mat H = cv::estimateAffine2D(left_vec, right_vec, inlier_mask, cv::RANSAC,
+                                   ransacReprojThreshold, maxIters, confidence);
+
+  std::vector<InterestPoint> left_ip, right_ip;
+  for (size_t j = 0; j < filtered_cv_matches.size(); j++) {
+    int left_ip_index = filtered_cv_matches.at(j).queryIdx;
+    int right_ip_index = filtered_cv_matches.at(j).trainIdx;
+
+    if (inlier_mask.at<uchar>(j, 0) == 0) continue;
+
+    cv::Mat left_desc = left_descriptors.row(left_ip_index);
+    cv::Mat right_desc = right_descriptors.row(right_ip_index);
+
+    InterestPoint left;
+    left.setFromCvKeypoint(left_keypoints.col(left_ip_index), left_desc);
+
+    InterestPoint right;
+    right.setFromCvKeypoint(right_keypoints.col(right_ip_index), right_desc);
+
+    left_ip.push_back(left);
+    right_ip.push_back(right);
+  }
+
+  // Update the shared variable using a lock
+  match_mutex->lock();
+
+  // Print the verbose message inside the lock, otherwise the text
+  // may get messed up.
+  if (verbose)
+    std::cout << "Number of matches for pair "
+              << left_image_index << ' ' << right_image_index << ": "
+              << left_ip.size() << std::endl;
+
+  *matches = std::make_pair(left_ip, right_ip);
+  match_mutex->unlock();
+}
+
 void writeIpRecord(std::ofstream& f, InterestPoint const& p) {
   f.write(reinterpret_cast<const char*>(&(p.x)), sizeof(p.x));
   f.write(reinterpret_cast<const char*>(&(p.y)), sizeof(p.y));
@@ -210,6 +347,265 @@ void saveImagesAndMatches(std::string const& left_prefix, std::string const& rig
   std::string match_file = left_stem + "__" + right_stem + ".match";
   std::cout << "Writing: " << left_image_file << ' ' << right_image_file << ' ' << match_file << std::endl;
   writeMatchFile(match_file, match_pair.first, match_pair.second);
+}
+
+// Triangulate rays emanating from given undistorted and centered pixels
+Eigen::Vector3d TriangulatePair(double focal_length1, double focal_length2,
+                                Eigen::Affine3d const& world_to_cam1,
+                                Eigen::Affine3d const& world_to_cam2,
+                                Eigen::Vector2d const& pix1,
+                                Eigen::Vector2d const& pix2) {
+  Eigen::Matrix3d k1;
+  k1 << focal_length1, 0, 0, 0, focal_length1, 0, 0, 0, 1;
+
+  Eigen::Matrix3d k2;
+  k2 << focal_length2, 0, 0, 0, focal_length2, 0, 0, 0, 1;
+
+  openMVG::Mat34 cid_to_p1, cid_to_p2;
+  openMVG::P_From_KRt(k1, world_to_cam1.linear(), world_to_cam1.translation(), &cid_to_p1);
+  openMVG::P_From_KRt(k2, world_to_cam2.linear(), world_to_cam2.translation(), &cid_to_p2);
+
+  openMVG::Triangulation tri;
+  tri.add(cid_to_p1, pix1);
+  tri.add(cid_to_p2, pix2);
+
+  Eigen::Vector3d solution = tri.compute();
+  return solution;
+}
+
+// Triangulate n rays emanating from given undistorted and centered pixels
+Eigen::Vector3d Triangulate(std::vector<double>          const& focal_length_vec,
+                            std::vector<Eigen::Affine3d> const& world_to_cam_vec,
+                            std::vector<Eigen::Vector2d> const& pix_vec) {
+  if (focal_length_vec.size() != world_to_cam_vec.size() ||
+      focal_length_vec.size() != pix_vec.size())
+    LOG(FATAL) << "All inputs to Triangulate() must have the same size.";
+
+  if (focal_length_vec.size() <= 1)
+    LOG(FATAL) << "At least two rays must be passed to Triangulate().";
+
+  openMVG::Triangulation tri;
+
+  for (size_t it = 0; it < focal_length_vec.size(); it++) {
+    Eigen::Matrix3d k;
+    k << focal_length_vec[it], 0, 0, 0, focal_length_vec[it], 0, 0, 0, 1;
+
+    openMVG::Mat34 cid_to_p;
+    openMVG::P_From_KRt(k, world_to_cam_vec[it].linear(), world_to_cam_vec[it].translation(),
+                        &cid_to_p);
+
+    tri.add(cid_to_p, pix_vec[it]);
+  }
+
+  Eigen::Vector3d solution = tri.compute();
+  return solution;
+}
+
+void detectMatchFeatures(  // Inputs
+                         std::vector<dense_map::cameraImage> const& cams,
+                         std::vector<std::string> const& cam_names,
+                         std::vector<camera::CameraParameters> const& cam_params,
+                         std::vector<Eigen::Affine3d> const& world_to_cam, int num_overlaps,
+                         int initial_max_reprojection_error, int num_match_threads,
+                         bool verbose,
+                         // Outputs
+                         std::vector<std::vector<std::pair<float, float>>>& keypoint_vec,
+                         std::vector<std::map<int, int>>& pid_to_cid_fid,
+                         std::vector<std::string> & image_files) {
+  // Wipe the outputs
+  keypoint_vec.clear();
+  pid_to_cid_fid.clear();
+  image_files.clear();
+
+  if (verbose) {
+    int count = 10000;
+    for (size_t it = 0; it < cams.size(); it++) {
+      std::ostringstream oss;
+      oss << count << "_" << cam_names[cams[it].camera_type] << ".jpg";
+      std::string name = oss.str();
+      std::cout << "Writing: " << name << std::endl;
+      cv::imwrite(name, cams[it].image);
+      count++;
+      image_files.push_back(name);
+    }
+  }
+
+  // Detect features using multiple threads. Too many threads may result
+  // in high memory usage.
+  std::ostringstream oss;
+  oss << num_match_threads;
+  std::string num_threads = oss.str();
+  google::SetCommandLineOption("num_threads", num_threads.c_str());
+  if (!gflags::GetCommandLineOption("num_threads", &num_threads))
+    LOG(FATAL) << "Failed to get the value of --num_threads in Astrobee software.\n";
+  std::cout << "Using " << num_threads << " threads for feature detection/matching." << std::endl;
+
+  std::cout << "Detecting features." << std::endl;
+
+  std::vector<cv::Mat> cid_to_descriptor_map;
+  std::vector<Eigen::Matrix2Xd> cid_to_keypoint_map;
+  cid_to_descriptor_map.resize(cams.size());
+  cid_to_keypoint_map.resize(cams.size());
+  {
+    // Make the thread pool go out of scope when not needed to not use up memory
+    ff_common::ThreadPool thread_pool;
+    for (size_t it = 0; it < cams.size(); it++) {
+      thread_pool.AddTask
+        (&dense_map::detectFeatures,    // multi-thread  // NOLINT
+         // dense_map::detectFeatures(  // single-thread // NOLINT
+         cams[it].image, verbose, &cid_to_descriptor_map[it], &cid_to_keypoint_map[it]);
+    }
+    thread_pool.Join();
+  }
+
+  MATCH_MAP matches;
+
+  std::vector<std::pair<int, int> > image_pairs;
+  for (size_t it1 = 0; it1 < cams.size(); it1++) {
+    for (size_t it2 = it1 + 1; it2 < std::min(cams.size(), it1 + num_overlaps + 1); it2++) {
+      image_pairs.push_back(std::make_pair(it1, it2));
+    }
+  }
+
+  {
+    std::cout << "Matching features." << std::endl;
+    ff_common::ThreadPool thread_pool;
+    std::mutex match_mutex;
+    for (size_t pair_it = 0; pair_it < image_pairs.size(); pair_it++) {
+      auto pair = image_pairs[pair_it];
+      int left_image_it = pair.first, right_image_it = pair.second;
+      thread_pool.AddTask
+        (&dense_map::matchFeaturesWithCams,   // multi-threaded  // NOLINT
+         // dense_map::matchFeaturesWithCams( // single-threaded // NOLINT
+         &match_mutex, left_image_it, right_image_it, cam_params[cams[left_image_it].camera_type],
+         cam_params[cams[right_image_it].camera_type], world_to_cam[left_image_it],
+         world_to_cam[right_image_it], initial_max_reprojection_error,
+         cid_to_descriptor_map[left_image_it], cid_to_descriptor_map[right_image_it],
+         cid_to_keypoint_map[left_image_it], cid_to_keypoint_map[right_image_it], verbose,
+         &matches[pair]);
+    }
+    thread_pool.Join();
+  }
+  cid_to_descriptor_map = std::vector<cv::Mat>();  // Wipe, takes memory
+
+  // Give all interest points in a given image a unique id, and put
+  // them in a vector with the id corresponding to the interest point
+  std::vector<std::map<std::pair<float, float>, int>> keypoint_map(cams.size());
+  for (auto it = matches.begin(); it != matches.end(); it++) {
+    std::pair<int, int> const& index_pair = it->first;     // alias
+
+    int left_index = index_pair.first;
+    int right_index = index_pair.second;
+
+    dense_map::MATCH_PAIR const& match_pair = it->second;  // alias
+    std::vector<dense_map::InterestPoint> const& left_ip_vec = match_pair.first;
+    std::vector<dense_map::InterestPoint> const& right_ip_vec = match_pair.second;
+    for (size_t ip_it = 0; ip_it < left_ip_vec.size(); ip_it++) {
+      auto dist_left_ip  = std::make_pair(left_ip_vec[ip_it].x,  left_ip_vec[ip_it].y);
+      auto dist_right_ip = std::make_pair(right_ip_vec[ip_it].x, right_ip_vec[ip_it].y);
+      // Initialize to zero for the moment
+      keypoint_map[left_index][dist_left_ip] = 0;
+      keypoint_map[right_index][dist_right_ip] = 0;
+    }
+  }
+  keypoint_vec.resize(cams.size());
+  for (size_t cid = 0; cid < cams.size(); cid++) {
+    keypoint_vec[cid].resize(keypoint_map[cid].size());
+    int fid = 0;
+    for (auto ip_it = keypoint_map[cid].begin(); ip_it != keypoint_map[cid].end();
+         ip_it++) {
+      auto& dist_ip = ip_it->first;  // alias
+      keypoint_map[cid][dist_ip] = fid;
+      keypoint_vec[cid][fid] = dist_ip;
+      fid++;
+    }
+  }
+
+  // If feature A in image I matches feather B in image J, which
+  // matches feature C in image K, then (A, B, C) belong together in
+  // a track, and will have a single triangulated xyz. Build such a track.
+
+  openMVG::matching::PairWiseMatches match_map;
+  for (auto it = matches.begin(); it != matches.end(); it++) {
+    std::pair<int, int> const& index_pair = it->first;     // alias
+
+    int left_index = index_pair.first;
+    int right_index = index_pair.second;
+
+    dense_map::MATCH_PAIR const& match_pair = it->second;  // alias
+    std::vector<dense_map::InterestPoint> const& left_ip_vec = match_pair.first;
+    std::vector<dense_map::InterestPoint> const& right_ip_vec = match_pair.second;
+
+    std::vector<openMVG::matching::IndMatch> mvg_matches;
+
+    for (size_t ip_it = 0; ip_it < left_ip_vec.size(); ip_it++) {
+      auto dist_left_ip  = std::make_pair(left_ip_vec[ip_it].x,  left_ip_vec[ip_it].y);
+      auto dist_right_ip = std::make_pair(right_ip_vec[ip_it].x, right_ip_vec[ip_it].y);
+
+      int left_id = keypoint_map[left_index][dist_left_ip];
+      int right_id = keypoint_map[right_index][dist_right_ip];
+      mvg_matches.push_back(openMVG::matching::IndMatch(left_id, right_id));
+    }
+    match_map[index_pair] = mvg_matches;
+  }
+
+  if (verbose) {
+    for (auto it = matches.begin(); it != matches.end(); it++) {
+      std::pair<int, int> index_pair = it->first;
+      dense_map::MATCH_PAIR const& match_pair = it->second;
+
+      int left_index = index_pair.first;
+      int right_index = index_pair.second;
+
+      std::string left_image = image_files[left_index];
+      std::string right_image = image_files[right_index];
+
+      std::string left_stem = boost::filesystem::path(left_image).stem().string();
+      std::string right_stem = boost::filesystem::path(right_image).stem().string();
+
+      std::string match_file = left_stem + "__" + right_stem + ".match";
+
+      std::cout << "Writing: " << left_image << ' ' << right_image << ' '
+                << match_file << std::endl;
+      dense_map::writeMatchFile(match_file, match_pair.first, match_pair.second);
+    }
+  }
+
+  // De-allocate data not needed anymore and take up a lot of RAM
+  matches.clear(); matches = MATCH_MAP();
+  keypoint_map.clear(); keypoint_map.shrink_to_fit();
+  cid_to_keypoint_map.clear(); cid_to_keypoint_map.shrink_to_fit();
+
+  {
+    // Build tracks
+    // De-allocate these as soon as not needed to save memory
+    openMVG::tracks::TracksBuilder trackBuilder;
+    trackBuilder.Build(match_map);  // Build:  Efficient fusion of correspondences
+    trackBuilder.Filter();          // Filter: Remove tracks that have conflict
+    // trackBuilder.ExportToStream(std::cout);
+    // Export tracks as a map (each entry is a sequence of imageId and featureIndex):
+    //  {TrackIndex => {(imageIndex, featureIndex), ... ,(imageIndex, featureIndex)}
+    openMVG::tracks::STLMAPTracks map_tracks;
+    trackBuilder.ExportToSTL(map_tracks);
+    match_map = openMVG::matching::PairWiseMatches();  // wipe this, no longer needed
+    trackBuilder = openMVG::tracks::TracksBuilder();   // wipe it
+
+    if (map_tracks.empty())
+      LOG(FATAL) << "No tracks left after filtering. Perhaps images are too dis-similar?\n";
+
+    // Populate the filtered tracks
+    size_t num_elems = map_tracks.size();
+    pid_to_cid_fid.resize(num_elems);
+    size_t curr_id = 0;
+    for (auto itr = map_tracks.begin(); itr != map_tracks.end(); itr++) {
+      for (auto itr2 = (itr->second).begin(); itr2 != (itr->second).end(); itr2++) {
+        pid_to_cid_fid[curr_id][itr2->first] = itr2->second;
+      }
+      curr_id++;
+    }
+  }
+
+  return;
 }
 
 }  // end namespace dense_map


### PR DESCRIPTION
This commit modularizes camera refiner, fixes a recent bug in resizing images, and makes it possible to save filtered matches for visualization.

Also some work was done in the streaming mapper to save the .obj files in double precision rather than float, which matters for large meshes, and to make the texture buffer as square as possible, which also results in improved precision (for reasons too long to explain). 

While this diff is big, it was very carefully tested. 