### PR TITLE
Update CGAL installation instructions

### DIFF
--- a/dense_map/geometry_mapper/CMakeLists.txt
+++ b/dense_map/geometry_mapper/CMakeLists.txt
@@ -92,7 +92,7 @@ set(TEXRECON_DIR ${CMAKE_BINARY_DIR}/texrecon)
 ExternalProject_Add(texrecon	
     PREFIX ${TEXRECON_DIR}
     GIT_REPOSITORY https://github.com/oleg-alexandrov/mvs-texturing.git
-    GIT_TAG f877c6d
+    GIT_TAG 2aa273f
     CMAKE_ARGS -DCMAKE_VERBOSE_MAKEFILE=TRUE -DCMAKE_CXX_FLAGS=-fPIC
     BUILD_COMMAND $(MAKE)
     # Per: https://cmake.org/pipermail/cmake/2011-April/043772.html,

--- a/dense_map/geometry_mapper/readme.md
+++ b/dense_map/geometry_mapper/readme.md
@@ -193,14 +193,28 @@ This should end up creating the program:
 
 ### Compiling CGAL
 
-Compile the CGAL tools following the instructions at:
+Compile the CGAL tools using the commands:
 
-    https://github.com/oleg-alexandrov/cgal_tools
+    mkdir -p $HOME/projects
+    cd $HOME/projects
+    git clone https://github.com/oleg-alexandrov/cgal_tools
+    cd cgal_tools
+    git checkout d3467a9 
+    wget https://github.com/CGAL/cgal/releases/download/v5.3/CGAL-5.3.tar.xz
+    tar xfv CGAL-5.3.tar.xz
+    cmake . -DCMAKE_BUILD_TYPE=Release \
+      -DCGAL_DIR:PATH=CGAL-5.3
+    make -j 10
 
-This should create some programs in:
+CGAL will fail to build with cmake version 3.10 installed with Ubuntu
+18. It is suggested to fetch cmake version 3.15 or later.
+
+The outcome will be that some programs will be installed in:
 
     $HOME/projects/cgal_tools
  
+which will be later looked up by the geometry mapper.
+
 ### CGAL license    
 
 CGAL is released under the GPL. Care must be taken to not include it


### PR DESCRIPTION
I just realized that CGAL fails to compile with the default cmake 3.10 on Ubuntu 18, which is what astrobeast is running. I am not sure how Marina compiled it before. For now just making this clear in the instructions, and expanding the doc a bit as well.

At some point CGAL needs to be built automatically, rather than a separate job done by the user manually. I tried to implement that, but then ran into the cmake version problem, and I see no quick fix for that. Maybe when astrobeast is upgraded to Ubuntu 20 this issue will go away. 