### PR TITLE
Panorama stitching improvements

### DIFF
--- a/astrobee/behaviors/inspection/scripts/compare_pto.py
+++ b/astrobee/behaviors/inspection/scripts/compare_pto.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Compare PTO files.
+"""
+
+import argparse
+import array
+import os
+
+import hsi
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")  # must call before importing pyplot
+from matplotlib import pyplot as plt
+
+
+def read_pto(pano, pto_path):
+    ifs = hsi.ifstream(pto_path)
+    pano.readData(ifs)
+
+
+def get_params(pto_path, x_param, y_param, lonlat):
+    pano = hsi.Panorama()
+    read_pto(pano, pto_path)
+
+    result_in = array.array("d")
+    for i in range(pano.getNrOfImages()):
+        img = pano.getImage(i)
+        result_in.extend((img.getVar(x_param), img.getVar(y_param)))
+
+    result = np.array(result_in, dtype=np.float64).reshape((-1, 2))
+    if lonlat:
+        result = normalize_lonlat(result)
+    return result
+
+
+def xyz_from_lonlat(lonlat):
+    lon = lonlat[:, 0] * np.pi / 180
+    lat = lonlat[:, 1] * np.pi / 180
+    result = np.array(
+        (np.cos(lat) * np.cos(lon), np.cos(lat) * np.sin(lon), np.sin(lat))
+    ).T
+    return result
+
+
+def lonlat_from_xyz(xyz):
+    x = xyz[:, 0]
+    y = xyz[:, 1]
+    z = xyz[:, 2]
+    lon = np.arctan2(y, x)
+    lat = np.arctan2(z, np.sqrt(x * x + y * y))
+    return np.array((lon * 180 / np.pi, lat * 180 / np.pi)).T
+
+
+def normalize_lonlat(lonlat):
+    return lonlat_from_xyz(xyz_from_lonlat(lonlat))
+
+
+def lon_wrap_line(x_line, y_line):
+    x1, x2 = x_line
+    y1, y2 = y_line
+    if abs(x1 - x2) > 180:
+        if x1 < x2:
+            x1, x2 = x2, x1
+            y1, y2 = y2, y1
+        x2p = x2 + 360
+        yb = y1 + (y2 - y1) * (180 - x1) / (x2p - x1)
+        return (x1, 180, -180, x2), (y1, yb, yb, y2)
+    else:
+        return x_line, y_line
+
+
+def lon_wrap_lines(x, y):
+    xa = array.array("d")
+    ya = array.array("d")
+    for x_line, y_line in zip(x.T, y.T):
+        x_lines, y_lines = lon_wrap_line(x_line, y_line)
+        xa.extend(x_lines)
+        ya.extend(y_lines)
+    x_out = np.array(xa, dtype=np.float64).reshape((-1, 2)).T
+    y_out = np.array(ya, dtype=np.float64).reshape((-1, 2)).T
+    return x_out, y_out
+
+
+def plot_params(ptos, x_param, y_param, out_path, lonlat=False):
+    fig, ax = plt.subplots()
+    prev_data = None
+
+    for pto in ptos:
+        data = get_params(pto, x_param, y_param, lonlat)
+        plt.plot(data[:, 0], data[:, 1], "+")
+        if prev_data is not None:
+            x = np.array([prev_data[:, 0], data[:, 0]])
+            y = np.array([prev_data[:, 1], data[:, 1]])
+            if lonlat:
+                x, y = lon_wrap_lines(x, y)
+            plt.plot(x, y, "-", color="gray")
+        prev_data = data
+
+    pos = ax.get_position()
+    ax.set_position([pos.x0, pos.y0, pos.width * 0.7, pos.height])
+    pto_names = [os.path.splitext(os.path.basename(pto))[0] for pto in ptos]
+    ax.legend(pto_names, loc="upper left", bbox_to_anchor=(1.05, 1))
+    plt.xlabel(x_param)
+    plt.ylabel(y_param)
+
+    if lonlat:
+        tick_size = 30
+        ax.set_xticks(range(-180, 180 + tick_size, tick_size))
+        ax.set_yticks(range(-90, 90 + tick_size, tick_size))
+        ax.axis([-180, 180, -90, 90])
+
+    plt.grid()
+    ax.axis("scaled")
+
+    # plt.tight_layout()
+    fig.set_size_inches((10, 5))
+
+    plt.savefig(out_path)
+    print("Wrote plot to %s" % out_path)
+    plt.close()
+
+
+def compare_pto(pto_paths):
+    plot_params(pto_paths, "y", "p", "compare_pto_y_p.png", lonlat=True)
+    plot_params(pto_paths, "Tpy", "Tpp", "compare_pto_Tpy_Tpp.png", lonlat=True)
+    plot_params(pto_paths, "y", "r", "compare_pto_y_r.png")
+
+
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+):
+    pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=CustomFormatter
+    )
+    parser.add_argument(
+        "pto",
+        nargs="+",
+        help="input pto path",
+    )
+    args = parser.parse_args()
+
+    compare_pto(args.pto)
+
+
+if __name__ == "__main__":
+    main()

--- a/astrobee/behaviors/inspection/scripts/downsample_pto.py
+++ b/astrobee/behaviors/inspection/scripts/downsample_pto.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Downsample pano input frames, metadata, control points, and requested output
+size in PTO. Convenient to speed up the rest of the stitching process when
+debugging.
+
+Example:
+  rosrun inspection scripts/downsample_pto.py in.pto --factor 4 out.pto
+"""
+
+import argparse
+import os
+
+import cv2
+import hsi
+
+
+def downsample_frame(in_path, out_path, factor):
+    print("  downsample_frame %s %s" % (in_path, out_path))
+
+    if os.path.exists(out_path):
+        print("    output file already exists, skipping")
+        return
+
+    im = cv2.imread(in_path, cv2.IMREAD_UNCHANGED)
+    rows, cols = im.shape[:2]
+    down_size = (int(cols / factor), int(rows / factor))
+    down_im = cv2.resize(im, down_size, interpolation=cv2.INTER_LINEAR)
+    cv2.imwrite(out_path, down_im)
+
+
+def read_pto(pano, pto_path):
+    ifs = hsi.ifstream(pto_path)
+    pano.readData(ifs)
+
+
+def write_pto(pano, pto_path):
+    ofs = hsi.ofstream(pto_path)
+    pano.writeData(ofs)
+
+
+def downsampled_path(in_path):
+    in_prefix, in_ext = os.path.splitext(in_path)
+    return in_prefix + "_down" + in_ext
+
+
+def downsample_pto(in_path, out_path, factor):
+    if os.path.exists(out_path):
+        print("Output file %s exists, not overwriting." % out_path)
+        return
+
+    pano = hsi.Panorama()
+    read_pto(pano, in_path)
+
+    # process input images
+    print("Downsampling:")
+    for i in range(pano.getNrOfImages()):
+        img = pano.getImage(i)
+        orig_path = img.getFilename()
+        down_path = downsampled_path(orig_path)
+
+        # downsample image
+        downsample_frame(orig_path, down_path, factor)
+
+        # update pto: point to dowsampled image
+        img.setFilename(down_path)
+
+        # update pto: image width and height
+        img_size = img.getSize()
+        img_size.x = int(img_size.x / factor)
+        img_size.y = int(img_size.y / factor)
+        img.setSize(img_size)
+
+    # process control points
+    pts = pano.getCtrlPoints()
+    for pt in pts:
+        pt.x1 /= factor
+        pt.x2 /= factor
+        pt.y1 /= factor
+        pt.y2 /= factor
+    pano.setCtrlPoints(pts)
+
+    # reduce size of output pano
+    opts = pano.getOptions()
+    w, h = opts.getWidth(), opts.getHeight()
+    # Note: the setWidth() call sometimes auto-updates height, so it's important
+    # that we queried both w and h before setting either parameter.
+    opts.setWidth(int(w / factor))
+    opts.setHeight(int(h / factor))
+
+    write_pto(pano, out_path)
+    print("Wrote to %s" % out_path)
+
+
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+):
+    pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=CustomFormatter
+    )
+    parser.add_argument(
+        "in_pto",
+        type=str,
+        help="input pto path",
+    )
+    parser.add_argument(
+        "out_pto",
+        type=str,
+        help="output pto path",
+    )
+    parser.add_argument(
+        "-f",
+        "--factor",
+        type=float,
+        default=8,
+        help="downsample by specified factor",
+    )
+    args = parser.parse_args()
+
+    downsample_pto(args.in_pto, args.out_pto, args.factor)
+
+
+if __name__ == "__main__":
+    main()

--- a/astrobee/behaviors/inspection/scripts/opencv_convert.py
+++ b/astrobee/behaviors/inspection/scripts/opencv_convert.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Convenience script for converting image formats (with optional resizing) using
+OpenCV. You may find it useful for large panorama images because OpenCV has
+larger image size limits than ImageMagick convert.
+
+Example:
+  rosrun inspection scripts/opencv_convert.py pano.png -resize 4000x4000 pano_small.jpg
+"""
+
+import argparse
+
+import cv2
+
+
+def opencv_convert(in_path, out_path, resize):
+    im = cv2.imread(in_path, cv2.IMREAD_UNCHANGED)
+
+    if resize:
+        # parse input string
+        w_str, h_str = resize.split("x")
+        w = int(w_str)
+        h = int(h_str)
+
+        # preserve aspect ratio, interpreting requested dimensions as limits on
+        # output width and height, like ImageMagick convert.
+        in_h, in_w = im.shape[:2]
+        scale_factor = min(float(w) / in_w, float(h) / in_h)
+        resize_aspect = tuple([int(round(scale_factor * val)) for val in (in_w, in_h)])
+
+        # perform resize operation
+        im = cv2.resize(im, resize_aspect, interpolation=cv2.INTER_CUBIC)
+
+    cv2.imwrite(out_path, im)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "in_image",
+        type=str,
+        help="input image path",
+    )
+    parser.add_argument(
+        "out_image",
+        type=str,
+        help="output image path",
+    )
+    parser.add_argument(
+        "-r",
+        "--resize",
+        type=str,
+        default=None,
+        help="limit output size to specified dimensions, like '640x480'. Input aspect ratio will be preserved within the specified limits.",
+    )
+    args = parser.parse_args()
+
+    opencv_convert(args.in_image, args.out_image, args.resize)
+
+
+if __name__ == "__main__":
+    main()

--- a/astrobee/behaviors/inspection/scripts/pano_image_meta.py
+++ b/astrobee/behaviors/inspection/scripts/pano_image_meta.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# Copyright (c) 2017, United States Government, as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+#
+# All rights reserved.
+#
+# The Astrobee platform is licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Extract pano image poses and write to CSV for convenient debug plotting.
+"""
+
+import argparse
+import csv
+
+import rosbag
+from tf.transformations import euler_from_quaternion
+
+IMAGE_TOPIC = "/hw/cam_sci/compressed"
+POSE_TOPIC = "/loc/pose"
+FIELD_NAMES = (
+    "timestamp",
+    "img_path",
+    "x",
+    "y",
+    "z",
+    "roll",
+    "pitch",
+    "yaw",
+)
+
+
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+):
+    pass
+
+
+def get_image_meta(inbag_path):
+    images = []
+    with rosbag.Bag(inbag_path) as bag:
+        img_meta = None
+        for topic, msg, t in bag.read_messages([IMAGE_TOPIC, POSE_TOPIC]):
+            if topic == IMAGE_TOPIC:
+                img_meta = {}
+                images.append(img_meta)
+
+                # fill meta from image message
+                img_meta["timestamp"] = (
+                    msg.header.stamp.secs + 1e-9 * msg.header.stamp.nsecs
+                )
+                img_meta["img_path"] = "%d.%03d.jpg" % (
+                    msg.header.stamp.secs,
+                    msg.header.stamp.nsecs * 1e-6,
+                )
+
+            if img_meta is not None and topic == POSE_TOPIC:
+                # fill meta from the next pose message after the image message
+                img_meta["x"] = msg.pose.position.x
+                img_meta["y"] = msg.pose.position.y
+                img_meta["z"] = msg.pose.position.z
+
+                orientation_list = [
+                    msg.pose.orientation.x,
+                    msg.pose.orientation.y,
+                    msg.pose.orientation.z,
+                    msg.pose.orientation.w,
+                ]
+                (roll, pitch, yaw) = euler_from_quaternion(orientation_list)
+                img_meta["roll"] = roll
+                img_meta["pitch"] = pitch
+                img_meta["yaw"] = yaw
+
+                img_meta = None
+
+    return images
+
+
+def pano_image_meta(in_bag, out_csv):
+    images = get_image_meta(in_bag)
+    with open(out_csv, "w") as out:
+        writer = csv.DictWriter(out, fieldnames=FIELD_NAMES)
+        writer.writeheader()
+        for img_meta in images:
+            writer.writerow(img_meta)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=CustomFormatter
+    )
+    parser.add_argument(
+        "in_bag",
+        type=str,
+        help="Input bagfile containing SciCam images and pose messages.",
+    )
+    parser.add_argument(
+        "out_csv",
+        type=str,
+        help="Output CSV with metadata",
+    )
+    args = parser.parse_args()
+
+    pano_image_meta(args.in_bag, args.out_csv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Main changes:
- Preprocess input frames with Oleg's `undistort_image` tool, so we benefit from our pre-calibrated and validated SciCam lens model and Hugin doesn't need to include any lens parameters in its complicated optimization. After this change, you may prefer to use the `--no-lens` flag to disable Hugin optimizing lens parameters.
- Changed `enblend` options to use less advanced but more robust seam generator, which fixed some but not all black dropouts (this could vary depending on the pano).
- Changed how the output is structured. All generated files are placed under an output folder whose name is generated from the input bag filename. Within that folder, there is a `build` folder that contains all of the intermediate files. Only the final stitched output is placed outside of `build`. This is intended to make it easy to clean up after a run.
- The previous version made repeated in-place modifications of the Hugin PTO file. This version writes each updated PTO file to a new filename, keeping all PTO versions in a numbered sequence, for debugging.
- The previous version suppressed most console output from child processes, which occasionally would accidentally hide warnings. This version calls child processes in a different way that surfaces their output. It also duplicates all console output to a log file so you can review everything later.
- Some flag names tweaked to be more intuitive.
- Added `--no-translation` flag to disable translation parameter optimization. Translation optimization normally helps significantly, but it can converge to strange values that cause sections of images to be lost during remapping. This is known to cause some of the black dropouts. If you observe dropouts, you can check if disabling translation produces a better result.
- Added `--skip-images` flag. Occasionally a panorama can be improved by dropping an input image that has poor quality or can't be stitched for some reason (e.g., robot position drifted way off).
- Added debug script `downsample_pto.py`. Example use case: if you are experimenting with improving the remapping or blending steps, you can use `downsample_pto.py` to downsample the input images and adjust the PTO to match, then later calls to `stitch_panorama.py --stitching-only` will run much faster.
- Added debug script `compare_pto.py`. Example use case: Compare the yaw/pitch values between the initial PTO file and the final PTO used for stitching. (If the pano is well-behaved, optimization will typically not change the yaw/pitch values much. If some of them move a long way, it suggests a problem and hints which images have issues.)
- Added helper script `opencv_convert.py`. Example use case: Downsampling a gigantic output panorama to create a smaller JPEG preview that you can easily download for viewing. It can overcome image size limitations with the ImageMagick `convert` tool.