### PR TITLE
pin python linters at same versions as astrobee repo

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,8 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install linters
       run: |
-        pip install black
-        pip install isort
+        pip install click==8.0.1 black==22.1.0 isort==5.10.1
 
     - name: Run black
       run: |


### PR DESCRIPTION
The Black style changed slightly and gave new errors in Python scripts I didn't modify. I see the same problem must have come up in the `astrobee` repo, so we can follow the same solution here.