### PR TITLE
ci: bump to checkout@v3

### DIFF
--- a/.github/workflows/apk.yaml
+++ b/.github/workflows/apk.yaml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/
@@ -59,13 +59,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/
@@ -105,13 +105,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/
@@ -74,13 +74,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/
@@ -133,13 +133,13 @@ jobs:
     steps:
 
     - name: Checkout Astrobee
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: nasa/astrobee
         path: astrobee/
 
     - name: Checkout ISAAC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
         path: isaac/

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Checkout submodule
       run: git submodule update --init --depth 1 isaac_msgs
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Checkout submodule
       run: git submodule update --init --depth 1 isaac_msgs
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Checkout submodule
       run: git submodule update --init --depth 1 isaac_msgs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: repo/
     - name: Checkout gh-pages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: docs/
         ref: gh-pages

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check repo for lint errors
       run: ./scripts/git/cpplint_repo.py .
 
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install linters
       run: |
         pip install click==8.0.1 black==22.1.0 isort==5.10.1


### PR DESCRIPTION
Action checkout@v2 is deprecated. Parallel to https://github.com/nasa/astrobee/pull/673 in `astrobee` repo.