### PR TITLE
Update install instructions and scripts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,24 +19,25 @@ any other operating system or Ubuntu versions.*
 support running ISAAC Software on 32-bit systems.*
 
 **The `isaac` repo depends on some `astrobee` packages, therefore, `astrobee` needs to be installed beforehand.**
-
+See the [Astrobee Robot Software Installation Instructions](https://nasa.github.io/astrobee/html/md_INSTALL.html) for detailed setup instructions.
 
 Checkout the project source code
 ---------
 
 At this point you need to decide where you'd like to put the ISAAC workspace and code
-(`ISAAC_WS`) on your machine (add this to your .bashrc for persistency):
+(`ISAAC_WS`) on your machine, add this to your ``.bashrc`` or ``.zshrc`` for persistence:
 
     export ISAAC_WS=$HOME/isaac
 
 First, clone the flight software repository:
 
-    git clone --recursive https://github.com/nasa/isaac.git \
-    --branch develop $ISAAC_WS/src/
+    git clone --recursive https://github.com/nasa/isaac.git --branch develop $ISAAC_WS/src
 
 Checkout the submodule:
 
+    pushd $ISAAC_WS/src
     git submodule update --init --recursive
+    popd
 
 
 Dependencies
@@ -47,8 +48,7 @@ Next, install all required dependencies:
 *Note: Before running this please ensure that your system is completely updated
     by running 'sudo apt-get update' and then 'sudo apt-get upgrade'*
 
-    pushd $ISAAC_WS/src
-    cd scripts/setup
+    pushd $ISAAC_WS/src/scripts/setup
     ./install_desktop_packages.sh
     ./build_install_dependencies.sh
     sudo rosdep init
@@ -58,13 +58,6 @@ Next, install all required dependencies:
 Configuring the build
 ---------
 
-By default, the catkin uses the following paths:
-  - devel build path: `$ISAAC_WS/devel`
-  - install build path: `$ISAAC_WS/install`
-
-Building the code
----------
-    
 Source your astrobee build environment, for example as:
 
     source $ASTROBEE_WS/devel/setup.bash
@@ -74,29 +67,41 @@ that `configure.sh` is simply a wrapper around CMake that provides an easy way
 of turning on and off options. To see which options are supported, simply run
 `configure.sh -h`.
 
-    pushd $ASTROBEE_WS
+    pushd $ISAAC_WS
     ./src/scripts/configure.sh -l
     source ~/.bashrc
     popd
 
-The configure script modifies your ``.bashrc`` to source ``setup.bash`` for 
+If you run a Zsh session, then
+
+    pushd $ISAAC_WS
+    ./src/scripts/configure.sh -l
+    source ~/.zshrc
+    popd
+
+By default, the catkin uses the following paths:
+  - devel build path: `$ISAAC_WS/devel`
+  - install build path: `$ISAAC_WS/install`
+If you want to explicitly specify the workspace and/or install directories, set `$WORKSPACE_PATH` and `$INSTALL_PATH` to the desired paths and use the `-p` ad `-w` flags as shown:
+
+    $ISAAC_WS/src/scripts/configure.sh -l -p $INSTALL_PATH -w $WORKSPACE_PATH
+
+*Note: If a workspace is specified but not an explicit install directory,
+install location will be $WORKSPACE_PATH/install.*
+
+The configure script modifies your ``.bashrc``/``.zshrc`` to source ``setup.bash``/``setup.zsh`` for
 the current ROS distribution and to set CMAKE_PREFIX_PATH. It is suggested
 to examine it and see if all changes were made correctly.
 
-If you want to explicitly specify the workspace and/or install directories, use
-instead:
-
-    ./scripts/configure.sh -l -p $INSTALL_PATH -w $WORKSPACE_PATH
-
-*Note: If a workspace is specified but not an explicit install distectory,
-install location will be $WORKSPACE_PATH/install.*
+Building the code
+---------
 
 To build, run `catkin build` in the `$WORKSPACE_PATH`. Note that depending on your host
 machine, this might take in the order of tens of minutes to complete the first
 time round. Future builds will be faster, as only changes to the code are
 rebuilt, and not the entire code base.
 
-    pushd $ASTROBEE_WS
+    pushd $ISAAC_WS
     catkin build
     popd
 
@@ -107,7 +112,7 @@ The next steps are only for running ISAAC onboard Astrobee.
 Cross-compiling isaac (NASA only)
 ---------
 
-To cross-compile ISAAC, one must first cross compile the astobee code using the NASA_INSTALL instructions. Note that `ASTROBEE_WS` must be defined!!!
+To cross-compile ISAAC, one must first cross compile the astobee code using the NASA_INSTALL instructions. Note that `ASTROBEE_WS` and `ARMHF_CHROOT_DIR` must be defined!
 
 
 Cross compiling for the robot follows the same process, except the configure
@@ -119,7 +124,9 @@ script takes a `-a` flag instead of `-l`.
 
 Or with explicit build and install paths:
 
-    ./scripts/configure.sh -a -p $INSTALL_PATH -w $WORKSPACE_PATH
+    pushd $ISAAC_WS
+    ./src/scripts/configure.sh -a -p $INSTALL_PATH -w $WORKSPACE_PATH
+    popd
 
 *Warning: `$INSTALL_PATH` and `$WORKSPACE_PATH` used for cross compiling HAVE to be
 different than the paths for native build! See above for the default values 
@@ -148,4 +155,14 @@ Build ISAAC debian (NASA only)
 
 To build a debian you must first confirm that cross-compiling is functional. Once it is:
 
+    pushd $ISAAC_WS
     ./src/scripts/build/build_debian.sh
+    popd
+
+Switching build profiles
+---------
+
+To alternate between native and armhf (cross-compile) profiles:
+
+    catkin profile set native
+    catkin profile set armhf

--- a/scripts/build/build_debian.sh
+++ b/scripts/build/build_debian.sh
@@ -27,6 +27,11 @@ if [ -n "$(git status --porcelain)" ]; then
   exit -1
 fi
 
+# package `devscripts` is required in 20.04 to provide `debuild`
+if [ ${DIST} == "focal" ] && [ "$(dpkg -l | awk '/devscripts/ {print }'|wc -l)" -lt 1 ]; then
+  sudo apt install -y devscripts
+fi
+
 EXTRA_FLAGS="-b -aarmhf"
 
 # In some cases we may want to build for amd64 (e.g. astrobee-comms for users)

--- a/scripts/setup/dependencies/build_install_torch.sh
+++ b/scripts/setup/dependencies/build_install_torch.sh
@@ -31,10 +31,12 @@ sudo unzip -q libtorch-cxx11-abi-shared-with-deps-1.5.0+cpu.zip -d /usr/include
 #  if zsh is in use. We'll just add a conditional extension to every shell
 #  rc file we find (currently only looking at .bashrc and .zshrc)
 cmake_isaac_torch_path=/usr/include/libtorch/share/cmake/Torch
-for shell_cfg in "~/.bashrc" "~/.zshrc"; do
+for shell_cfg in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
     if [[ -f ${shell_cfg} ]] && [ $(grep -cF ${cmake_isaac_torch_path} ${shell_cfg}) -eq 0 ]; then
+        echo "Adding Torch CMAKE Prefix path to ${shell_cfg}"
         echo -e '\n## ISAAC Dependency - Torch CMAKE Path\n' >> ${shell_cfg}
         echo 'if [[ ":$CMAKE_PREFIX_PATH:" != *":'${cmake_isaac_torch_path}':"* ]]; then CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:+"$CMAKE_PREFIX_PATH:"}'${cmake_isaac_torch_path}'"; fi' >> ${shell_cfg}
     fi
 done
+
 echo "Torch added to CMAKE_PREFIX_PATH in shell config file, source ~/.$(basename ${SHELL})rc before building"


### PR DESCRIPTION
Improves setup documentation and scripting based on experience with a fresh 20.04 install.

- Fix typos in `INSTALL.md` and improve parallelism with Astrobee install docs
- Detect and install missing `devscripts` package when building Debians on 20.04
- Improve shell config detection when adding Torch CMake prefix path